### PR TITLE
fix: getTheme fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/theme-toolkit",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Theme helpers to use combined with Fluid React Elements ",
   "author": "Platform Builders <apps@platformbuilders.io>",
   "license": "ISC",

--- a/src/helpers/getTheme.ts
+++ b/src/helpers/getTheme.ts
@@ -3,6 +3,6 @@ import { FluidTheme, ThemeProps } from '../index';
 
 export const getTheme =
   (themeProp: Flatten<FluidTheme>) =>
-  ({ theme }: ThemeProps): string | number => {
-    return get(theme, themeProp) || '';
+  ({ theme }: ThemeProps): string | number | null => {
+    return get(theme, themeProp) || null;
   };


### PR DESCRIPTION
## Descrição do PR

Correção do fallback do getTheme. Testando junto ao template-react-native eu constatei que deu ruim.
A correção foi por null.

Retestei novamente junto ao template e tá tudo ok. 🙏 

#### Print do problema

![Captura de Tela 2022-11-28 às 21 35 05](https://user-images.githubusercontent.com/84453168/204413636-dec4de90-b846-4be7-b104-a135a38ca5af.png)

## Tipo de mudança

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [x] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Breaking change (ajuste ou funcionalidade que pode causar uma quebra numa funcionalidade já existente)

## Checklist 🚨

- [x] Meu código segue o code style da Builders
- [x] Testado usando Yalc
