### PR TITLE
Novo PxToRem

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,7 +33,7 @@ export default {
     commonjs({
       include: /node_modules/,
       namedExports: {
-        'node_modules/lodash/lodash.js': ['get', 'isFunction'],
+        'node_modules/lodash/lodash.js': ['get', 'isNumber', 'isFunction'],
       },
     }),
   ],

--- a/src/helpers/__tests__/pxToRem.test.ts
+++ b/src/helpers/__tests__/pxToRem.test.ts
@@ -1,6 +1,10 @@
+import theme from './mocks/themeFormated.json';
 import { pxToRem } from '../pxToRem';
 
-describe('getTheme()', () => {
+describe('pxToRem()', () => {
+  test('using theme', () => {
+    expect(pxToRem('spacing.md')({ theme })).toBe('1rem');
+  });
   test('should pxToRem(30) to be 1.875rem', () => {
     expect(pxToRem(30)).toBe('1.875rem');
   });

--- a/src/helpers/pxToRem.ts
+++ b/src/helpers/pxToRem.ts
@@ -1,3 +1,13 @@
-export const pxToRem = (pixels: number, baseline = 16): string => {
-  return `${pixels / baseline}rem`;
-};
+import { get, isNumber } from 'lodash';
+import { FluidTheme, ThemeProps } from '../index';
+
+export const pxToRem = (
+  param: Flatten<FluidTheme> | number,
+  baseline = 16,
+): any =>
+  isNumber(param)
+    ? `${param / baseline}rem`
+    : ({ theme }: ThemeProps): string => {
+        const pixel = get(theme, param) || 0;
+        return `${pixel / baseline}rem`;
+      };


### PR DESCRIPTION
## Descrição do PR

Agora o pxToRem pode acessar o tema diretamente, sem a necessidade de usar o getTheme antes.
`
const spacingMd = pxToRem('spacing.md');

`
## Tipo de mudança

- [x] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Breaking change (ajuste ou funcionalidade que pode causar uma quebra numa funcionalidade já existente)

## Checklist 🚨

- [x] Meu código segue o code style da Builders
- [x] Testado usando Yalc
