### PR TITLE
Format Value getTheme

### DIFF
--- a/src/helpers/__tests__/getTheme.test.ts
+++ b/src/helpers/__tests__/getTheme.test.ts
@@ -2,6 +2,13 @@ import theme from './mocks/themeFormated.json';
 import { getTheme } from '../getTheme';
 
 describe('getTheme()', () => {
+  test('should get rem spacing md', () => {
+    const spacingMd = getTheme('spacing.md', { format: 'rem' })({
+      theme,
+    });
+    expect(spacingMd).toBe('1rem');
+  });
+
   test('should get brand primary color', () => {
     const brandPrimaryColor = getTheme('brand.primary.main')({ theme });
     expect(brandPrimaryColor).toBe(theme.brand.primary.main);

--- a/src/helpers/getTheme.ts
+++ b/src/helpers/getTheme.ts
@@ -1,8 +1,18 @@
 import { get } from 'lodash';
+import { pxToRem } from './pxToRem';
 import { FluidTheme, ThemeProps } from '../index';
 
+enum TypeValue {
+  rem = 'rem'
+}
+
 export const getTheme =
-  (themeProp: Flatten<FluidTheme>) =>
+  (themeProp: Flatten<FluidTheme>, options?: { format: keyof typeof TypeValue }) =>
   ({ theme }: ThemeProps): string | number | null => {
-    return get(theme, themeProp) || null;
+    const parameter = get(theme, themeProp) || null;
+    if(options?.format === TypeValue.rem){
+      return pxToRem(parameter || 0);
+    }
+
+    return parameter;
   };

--- a/src/helpers/getTheme.ts
+++ b/src/helpers/getTheme.ts
@@ -1,16 +1,24 @@
 import { get } from 'lodash';
-import { pxToRem } from './pxToRem';
 import { FluidTheme, ThemeProps } from '../index';
+import { pxToRem } from './pxToRem';
 
 enum TypeValue {
-  rem = 'rem'
+  rem = 'rem',
 }
 
 export const getTheme =
-  (themeProp: Flatten<FluidTheme>, options?: { format: keyof typeof TypeValue }) =>
+  (
+    themeProp: Flatten<FluidTheme>,
+    options?: { format: keyof typeof TypeValue },
+  ) =>
   ({ theme }: ThemeProps): string | number | null => {
-    const parameter = get(theme, themeProp) || null;
-    if(options?.format === TypeValue.rem){
+    const parameter = get(theme, themeProp) || '';
+    if (
+      options?.format === TypeValue.rem ||
+      (!String(parameter).includes('rgb') &&
+        !String(parameter).includes('#') &&
+        !!document)
+    ) {
       return pxToRem(parameter || 0);
     }
 


### PR DESCRIPTION
## Descrição do PR

Adicionado tipo de formato no retorno do getTheme, agora retorna valores do tipo rem
`const spacingMd = getTheme('spacing.md', { format: 'rem' })`

## Tipo de mudança

- [x] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [ ] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Breaking change (ajuste ou funcionalidade que pode causar uma quebra numa funcionalidade já existente)

## Checklist 🚨

- [x] Meu código segue o code style da Builders
- [x] Testado usando Yalc
